### PR TITLE
[fix] fixed issue where variable name could not be found

### DIFF
--- a/ad/ad.py
+++ b/ad/ad.py
@@ -102,8 +102,8 @@ class Expression(object):
 class Variable(Expression):
     def __init__(self, name=None, grad=True):
         self.grad = grad
-        if name:
-            self.name = str(name)
+        self.name = None if not name else str(name)
+
         # A variable only depends on itself
         self.dep_vars = set([self])
     


### PR DESCRIPTION
Fixes the issue when I ran this sequence of commands
```bash
In [1]: import ad

In [2]: var = ad.Variable

In [3]: x = var()

In [4]: y = var()

In [5]: f = x * y ** 2

In [6]: f.eval({x: 5, y:5})
Out[6]: 125

In [7]: f.d({x: 5, y:5})
Out[7]: {Var: 25.0, Var: 50.0}
```

Before it threw an error because self.name wasn't initialized when printing as REPR